### PR TITLE
Feature enclosure

### DIFF
--- a/lib/feedparser/builder/atom.rb
+++ b/lib/feedparser/builder/atom.rb
@@ -205,9 +205,11 @@ class AtomFeedBuilder
 
     if atom_item.links
       enclosure = atom_item.links.detect{|x| x.rel == 'enclosure' }
-      item.enclosure[:url] = enclosure.href
-      item.enclosure[:length] = enclosure.length
-      item.enclosure[:type] = enclosure.type
+      if enclosure
+        item.enclosure[:url] = enclosure.href
+        item.enclosure[:length] = enclosure.length
+        item.enclosure[:type] = enclosure.type
+      end
     end
 
     item

--- a/lib/feedparser/builder/atom.rb
+++ b/lib/feedparser/builder/atom.rb
@@ -203,6 +203,13 @@ class AtomFeedBuilder
       item.tags << build_tag( atom_cat )
     end
 
+    if atom_item.links
+      enclosure = atom_item.links.detect{|x| x.rel == 'enclosure' }
+      item.enclosure[:url] = enclosure.href
+      item.enclosure[:length] = enclosure.length
+      item.enclosure[:type] = enclosure.type
+    end
+
     item
   end # method build_item
 

--- a/lib/feedparser/builder/rss.rb
+++ b/lib/feedparser/builder/rss.rb
@@ -181,6 +181,13 @@ class RssFeedBuilder
       item.tags << build_tag( rss_cat )
     end
 
+    
+    if rss_item.enclosure
+      item.enclosure[:url] = rss_item.enclosure.url
+      item.enclosure[:length] = rss_item.enclosure.length
+      item.enclosure[:type] = rss_item.enclosure.type
+    end
+
 
     item
   end # method build_feed_item_from_rss

--- a/lib/feedparser/item.rb
+++ b/lib/feedparser/item.rb
@@ -81,10 +81,16 @@ class Item
 
   alias :categories :tags    # for now allow categories alias for tags - remove (why? why not?)
 
+  # a hash containing the values of the first media enclosure. The hash will contain its attributes, specifically url,
+  # length and type
+  attr_accessor :enclosure
+
   def initialize
     ## note: make authors, tags empty arrays on startup (e.g. not nil)
-    @authors = []
-    @tags    = []
+    @authors    = []
+    @tags       = []
+    @enclosure  = {}
+    puts 'init'
   end
 
 end  # class Item

--- a/test/test_atom_live.rb
+++ b/test/test_atom_live.rb
@@ -43,4 +43,10 @@ class TestAtomLive < MiniTest::Test
     assert_equal 'http://blog.headius.com/', feed.url
   end
 
+  def test_enclosure
+    feed = fetch_and_parse_feed( 'http://www.lse.ac.uk/assets/richmedia/webFeeds/publicLecturesAndEvents_AtomAllMediaTypesLatest100.xml' )
+
+    assert_equal 'audio/mpeg',    feed.items.first.enclosure[:type]
+  end
+  
 end

--- a/test/test_rss_live.rb
+++ b/test/test_rss_live.rb
@@ -35,4 +35,10 @@ class TestRssLive < MiniTest::Test
     assert_equal 'rss 2.0', feed.format
   end
 
+  def test_enclosure
+    feed = fetch_and_parse_feed( 'http://www.radiofreesatan.com/category/featured/feed/' )
+
+    assert_equal 'audio/mpeg',    feed.items.first.enclosure[:type]
+  end
+
 end


### PR DESCRIPTION
Parse the media enclosure of RSS and Atom feeds, and adds a media enclosure attribute to FeedParser::Item.

`@enclosure` here is a hash, as the enclosure attribute transports its values as attributes. In RSS, there is only url, length and type, this adopts those names. Atom has the same (url is called href), but it also has title and potentially more attributes. My approach here would ignore them.

Also, Atom could have multiple enclosures, rss only one (that actually depends on the validator/parser, some allow more). This only takes the first. But one could instead use an array that contains hashes for each enclosure.

It might be preferable to introduce a value bag object instead of just using an array, but imho a hash is good enough.

The second commit contains some test cases. I just realized that there is an issue when there is no enclosure, I will add a third commit fixing that in a minute.