### PR TITLE
Make feedparser more reliable against dc_based malformed feeds (like craigslist)

### DIFF
--- a/lib/feedparser/builder/rss.rb
+++ b/lib/feedparser/builder/rss.rb
@@ -189,6 +189,14 @@ class RssFeedBuilder
       item.authors = authors
     end
 
+    unless item.published_local
+        # use dc_date only of no regular item date was given
+        begin
+            item.published_local   = handle_date( rss_item.dc_date, 'item.dc_date => published' )
+        rescue
+        end
+        item.published         = item.published_local.utc    if item.published_local
+    end
 
     ###  check for categories (tags)
     if rss_item.respond_to?(:categories)


### PR DESCRIPTION
Context of this is https://github.com/pipes-digital/pipes/issues/43.

The craigslist feed is not to spec, but works in readers like firefox, see https://newyork.craigslist.org/search/ggg?format=rss&amp;query=logo as an example. But feedparser choked on it, I think because the rss module does not create some methods feedparser is expecting. 

This PR adds try_catch blocks around optional assignments, checks for existing methods where it seemed more appropriate, and to make the feed output more useful it checks for `item.dc_date` as a fallback when `item.date` is missing.