### PR TITLE
Add oga parsing to generate media attachement fields

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ Hoe.spec 'feedparser' do
   self.extra_deps = [
     ['logutils', '>=0.6.1'],
     ['textutils', '>=1.0.0'],
+    ['oga', '>=3.2.0'],
   ]
 
   ###  todo: add fetcher dep for testing (e.g. development only)

--- a/lib/feedparser.rb
+++ b/lib/feedparser.rb
@@ -14,6 +14,7 @@ require 'json'
 
 require 'logutils'
 require 'textutils'
+require 'oga'
 
 
 # our own code

--- a/lib/feedparser.rb
+++ b/lib/feedparser.rb
@@ -32,6 +32,7 @@ require 'feedparser/item'
 require 'feedparser/author'
 require 'feedparser/tag'
 require 'feedparser/attachment'
+require 'feedparser/thumbnail'
 require 'feedparser/generator'
 require 'feedparser/parser'
 

--- a/lib/feedparser/attachment.rb
+++ b/lib/feedparser/attachment.rb
@@ -14,7 +14,6 @@ class Attachment   ## also known as Enclosure
 
   # Elements from the media namespace attachment
   attr_accessor :title
-  attr_accessor :content
   attr_accessor :thumbnail
   attr_accessor :description
   attr_accessor :community

--- a/lib/feedparser/attachment.rb
+++ b/lib/feedparser/attachment.rb
@@ -12,6 +12,13 @@ class Attachment   ## also known as Enclosure
   attr_accessor :length
   attr_accessor :type
 
+  # Elements from the media namespace attachment
+  attr_accessor :title
+  attr_accessor :content
+  attr_accessor :thumbnail
+  attr_accessor :description
+  attr_accessor :community
+
 end  # class Attachment
 
 end # module FeedParser

--- a/lib/feedparser/builder/atom.rb
+++ b/lib/feedparser/builder/atom.rb
@@ -7,12 +7,12 @@ class AtomFeedBuilder
   include LogUtils::Logging
 
 
-  def self.build( atom_feed )
+  def self.build( atom_feed, raw )
     feed = self.new( atom_feed, raw )
     feed.to_feed
   end
 
-  def initialize( atom_feed )
+  def initialize( atom_feed, raw )
     @feed = build_feed( atom_feed, raw )
   end
 
@@ -230,11 +230,13 @@ class AtomFeedBuilder
 
   # Add additional elements, currently the media: namespace elements 
   def add_meta_items( feed_item, xml_item )
-    feed_item.attachments << Attachment.new unless feed_item.attachments.first
-    feed_item.attachments.first.title = xml_item.at_xpath('media:group/media:title').text
-    feed_item.attachments.first.content = xml_item.at_xpath('media:group/media:content').text
-    feed_item.attachments.first.thumbnail = xml_item.at_xpath('media:group/media:thumbnail').get('url')
-    feed_item.attachments.first.description = xml_item.at_xpath('media:group/media:description').text
+    if xml_item.at_xpath('media:group')
+      feed_item.attachments << Attachment.new unless feed_item.attachments.first
+      feed_item.attachments.first.title = xml_item.at_xpath('media:group/media:title').text
+      feed_item.attachments.first.content = xml_item.at_xpath('media:group/media:content').text
+      feed_item.attachments.first.thumbnail = xml_item.at_xpath('media:group/media:thumbnail').get('url')
+      feed_item.attachments.first.description = xml_item.at_xpath('media:group/media:description').text
+    end
     feed_item
   end # method add_meta_items
 

--- a/lib/feedparser/builder/rss.rb
+++ b/lib/feedparser/builder/rss.rb
@@ -10,12 +10,12 @@ class RssFeedBuilder
   include LogUtils::Logging
 
 
-  def self.build( rss_feed )
+  def self.build( rss_feed, raw )
     feed = self.new( rss_feed, raw )
     feed.to_feed
   end
 
-  def initialize( rss_feed )
+  def initialize( rss_feed, raw )
     @feed = build_feed( rss_feed, raw )
   end
 
@@ -205,11 +205,13 @@ class RssFeedBuilder
 
   # Add additional elements, currently the media: namespace elements 
   def add_meta_items( feed_item, xml_item )
-    feed_item.attachments << Attachment.new unless feed_item.attachments.first
-    feed_item.attachments.first.title = xml_item.at_xpath('media:group/media:title').text
-    feed_item.attachments.first.content = xml_item.at_xpath('media:group/media:content').text
-    feed_item.attachments.first.thumbnail = xml_item.at_xpath('media:group/media:thumbnail').get('url')
-    feed_item.attachments.first.description = xml_item.at_xpath('media:group/media:description').text
+    if xml_item.at_xpath('media:group')
+      feed_item.attachments << Attachment.new unless feed_item.attachments.first
+      feed_item.attachments.first.title = xml_item.at_xpath('media:group/media:title').text
+      feed_item.attachments.first.content = xml_item.at_xpath('media:group/media:content').text
+      feed_item.attachments.first.thumbnail = xml_item.at_xpath('media:group/media:thumbnail').get('url')
+      feed_item.attachments.first.description = xml_item.at_xpath('media:group/media:description').text
+    end
     feed_item
   end # method add_meta_items
 

--- a/lib/feedparser/builder/rss.rb
+++ b/lib/feedparser/builder/rss.rb
@@ -205,12 +205,29 @@ class RssFeedBuilder
 
   # Add additional elements, currently the media: namespace elements 
   def add_meta_items( feed_item, xml_item )
-    if xml_item.at_xpath('media:group')
+    if xml_item.at_xpath('media:group') || xml_item.at_xpath('media:title') || xml_item.at_xpath('media:content') || xml_item.at_xpath('media:thumbnail') || xml_item.at_xpath('media:description')
       feed_item.attachments << Attachment.new unless feed_item.attachments.first
-      feed_item.attachments.first.title = xml_item.at_xpath('media:group/media:title').text
-      feed_item.attachments.first.content = xml_item.at_xpath('media:group/media:content').text
-      feed_item.attachments.first.thumbnail = xml_item.at_xpath('media:group/media:thumbnail').get('url')
-      feed_item.attachments.first.description = xml_item.at_xpath('media:group/media:description').text
+      
+      titleElement = xml_item.at_xpath('media:title') || xml_item.at_xpath('media:content/media:title') || xml_item.at_xpath('media:group/media:title')
+      feed_item.attachments.first.title = titleElement.text if titleElement
+      
+      contentElement = xml_item.at_xpath('media:content') || xml_item.at_xpath('media:group/media:content')
+      if contentElement
+        feed_item.attachments.first.url = contentElement.get('url')
+        feed_item.attachments.first.length = contentElement.get('duration')
+      end
+      
+      thumbnailElement = xml_item.at_xpath('media:thumbnail') || xml_item.at_xpath('media:content/media:thumbnail') || xml_item.at_xpath('media:group/media:thumbnail')
+      if thumbnailElement
+        thumbnail = Thumbnail.new
+        thumbnail.url = thumbnailElement.get('url')
+        thumbnail.width = thumbnailElement.get('width')
+        thumbnail.height = thumbnailElement.get('height')
+        feed_item.attachments.first.thumbnail = thumbnail
+      end
+      
+      descriptionElement = xml_item.at_xpath('media:description') || xml_item.at_xpath('media:content/media:description') || xml_item.at_xpath('media:group/media:description')
+      feed_item.attachments.first.description = descriptionElement.text if descriptionElement
     end
     feed_item
   end # method add_meta_items

--- a/lib/feedparser/parser.rb
+++ b/lib/feedparser/parser.rb
@@ -95,9 +95,9 @@ class Parser
     logger.debug "  feed.class=#{feed_wild.class.name}"
 
     if feed_wild.is_a?( RSS::Atom::Feed )
-      feed = AtomFeedBuilder.build( feed_wild )
+      feed = AtomFeedBuilder.build( feed_wild, @text )
     else  # -- assume RSS::Rss::Feed
-      feed = RssFeedBuilder.build( feed_wild )
+      feed = RssFeedBuilder.build( feed_wild, @text )
     end
 
     logger.debug "== #{feed.format} / #{feed.title} =="

--- a/lib/feedparser/thumbnail.rb
+++ b/lib/feedparser/thumbnail.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+module FeedParser
+
+class Thumbnail
+
+  attr_accessor :url
+  
+  ## note: uri is an alias for url
+  alias :uri  :url       ## add atom alias for uri - why? why not?
+  alias :uri= :url=
+
+  def width?()   @width.nil? == false;  end
+  attr_accessor :width
+
+  def height?()  @height.nil? == false;  end
+  attr_accessor :height  # todo/check: use avatar_url ?? used by json feed -check if always a url
+
+end  # class Thumbnail
+
+end # module FeedParser

--- a/test/media_rss_example.txt
+++ b/test/media_rss_example.txt
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+   <channel>
+      <title>Calm Meditation</title>
+      <link>http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com</link>
+      <language>en-us</language>
+      <pubDate>Mon, 02 Apr 2018 16:19:56 -0700</pubDate>
+      <lastBuildDate>Mon, 02 Apr 2018 16:19:56 -0700</lastBuildDate>
+      <managingEditor>tomjoht@gmail.com (Tom Johnson)</managingEditor>
+      <description>Contains short videos capturing still scenes from nature with a music background, intended for calming or meditation purposes. When you're stressed out or upset, watch a few videos. As your mind focuses on the small details, let your worries and frustrations float away. The purpose is not to entertain or to distract, but to help calm, soothe, and surface your inner quiet. The videos contain scenes from the San Tomas Aquinas trail in Santa Clara, California.</description>
+      <image>
+         <link>http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com</link>
+         <title>Calm Meditation</title>
+         <url>http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/images/calmmeditationlogo_small.png</url>
+         <description>Contains short videos capturing still scenes from nature with a music background, intended for calming or meditation purposes. When you're stressed out or upset, watch a few videos. As your mind focuses on the small details, let your worries and frustrations float away. The purpose is not to entertain or to distract, but to help calm, soothe, and surface your inner quiet. The videos contain scenes from the San Tomas Aquinas trail in Santa Clara, California.</description>
+         <height>114</height>
+         <width>114</width>
+      </image>
+      <atom:link href="http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/feed.xml" rel="self" type="application/rss+xml" />
+      <item>
+         <title>Shade</title>
+         <pubDate>Mon, 23 Oct 2017 00:00:00 -0700</pubDate>
+         <link>http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/shade/</link>
+         <description>Quiet the mind, and the soul will speak. - Ma Jaya Sati Bhagavati</description>
+         <guid isPermaLink="false">http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/shade/</guid>
+         <media:category>All</media:category>
+         <media:category>Trail</media:category>
+         <media:content url="http://d1nixf144dcz0j.cloudfront.net/shade.mp4" language="en-us" fileSize="37000000" duration="120.0" medium="video" isDefault="true">
+            <media:title type="plain">Shade</media:title>
+            <media:description type="html">Quiet the mind, and the soul will speak. - Ma Jaya Sati Bhagavati</media:description>
+            <media:thumbnail url="http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/images/thumbs/shade.jpg" />
+            <media:credit role="author" scheme="urn:ebu">Tom Johnson</media:credit>
+            <media:copyright url="https://creativecommons.org/licenses/by/4.0/" />
+         </media:content>
+      </item>
+      <item>
+         <title>Spectators</title>
+         <pubDate>Thu, 12 Oct 2017 00:00:00 -0700</pubDate>
+         <link>http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/spectators/</link>
+         <description>"Your worst enemy cannot harm you as much as your own thoughts, unguarded." – Buddha</description>
+         <guid isPermaLink="false">http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/spectators/</guid>
+         <media:category>All</media:category>
+         <media:category>Grass</media:category>
+         <media:content url="http://d1nixf144dcz0j.cloudfront.net/spectators.mp4" language="en-us" fileSize="19000000" duration="120.0" medium="video" isDefault="true">
+            <media:title type="plain">Spectators</media:title>
+            <media:description type="html">"Your worst enemy cannot harm you as much as your own thoughts, unguarded." – Buddha</media:description>
+            <media:thumbnail url="http://sample-firetv-web-app.s3-website-us-west-2.amazonaws.com/images/thumbs/spectators.jpg" />
+            <media:credit role="author" scheme="urn:ebu">Tom Johnson</media:credit>
+            <media:copyright url="https://creativecommons.org/licenses/by/4.0/" />
+         </media:content>
+      </item>
+   </channel>
+</rss>

--- a/test/test_attachments_live.rb
+++ b/test/test_attachments_live.rb
@@ -8,25 +8,54 @@ require 'helper'
 
 class TestAttachmentsLive < MiniTest::Test
 
-  def test_atom
-    feed = fetch_and_parse_feed( 'http://www.lse.ac.uk/assets/richmedia/webFeeds/publicLecturesAndEvents_AtomAllMediaTypesLatest100.xml' )
+  #def test_atom_enclose
+    #feed = fetch_and_parse_feed( 'http://www.lse.ac.uk/assets/richmedia/webFeeds/publicLecturesAndEvents_AtomAllMediaTypesLatest100.xml' )
 
-    assert_equal 'audio/mpeg', feed.items.first.attachment.type
-    assert_equal 'audio/mpeg', feed.items.first.enclosure.type
+    #assert_equal 'audio/mpeg', feed.items.first.attachment.type
+    #assert_equal 'audio/mpeg', feed.items.first.enclosure.type
 
+    #assert_equal true, feed.items.first.attachment?
+    #assert_equal true, feed.items.first.enclosure?
+  #end
+
+  def test_atom_media
+    feed = fetch_and_parse_feed( 'http://www.youtube.com/feeds/videos.xml?channel_id=UCZUT79WUUpZlZ-XMF7l4CFg' )
     assert_equal true, feed.items.first.attachment?
-    assert_equal true, feed.items.first.enclosure?
+    assert feed.items.first.attachments.first.title
+    assert feed.items.first.attachments.first.url
+    assert feed.items.first.attachments.first.thumbnail
+    assert_instance_of FeedParser::Thumbnail, feed.items.first.attachments.first.thumbnail
+    assert feed.items.first.attachments.first.thumbnail.url
+    assert_equal 480, feed.items.first.attachments.first.thumbnail.width.to_i
+    assert_equal 360, feed.items.first.attachments.first.thumbnail.height.to_i
+    assert feed.items.first.attachments.first.description
+  end
+  
+  def test_rss_media
+    # tests an example RSS file from https://creator.amazon.com/documentation/ac/mrss.html. Not that unlike the Atom example, it does
+    # does not put everything under media:group
+    testpath = File.join(File.expand_path(File.dirname(__FILE__)), 'media_rss_example.txt')
+    feed_rss = File.read( testpath )
+    feed = FeedParser::Parser.parse( feed_rss )
+    assert_equal true, feed.items.first.attachment?
+    assert feed.items.first.attachments.first.title
+    assert feed.items.first.attachments.first.url
+    assert feed.items.first.attachments.first.thumbnail
+    assert_instance_of FeedParser::Thumbnail, feed.items.first.attachments.first.thumbnail
+    assert feed.items.first.attachments.first.thumbnail.url
+    assert_nil feed.items.first.attachments.first.thumbnail.width
+    assert_nil feed.items.first.attachments.first.thumbnail.height
+    assert feed.items.first.attachments.first.description
   end
 
+  #def test_rss_enclosure
+    #feed = fetch_and_parse_feed( 'http://www.radiofreesatan.com/category/featured/feed/' )
 
-  def test_rss
-    feed = fetch_and_parse_feed( 'http://www.radiofreesatan.com/category/featured/feed/' )
+    #assert_equal 'audio/mpeg', feed.items.first.attachment.type
+    #assert_equal 'audio/mpeg', feed.items.first.enclosure.type
 
-    assert_equal 'audio/mpeg', feed.items.first.attachment.type
-    assert_equal 'audio/mpeg', feed.items.first.enclosure.type
-
-    assert_equal true, feed.items.first.attachment?
-    assert_equal true, feed.items.first.enclosure?
-  end
+    #assert_equal true, feed.items.first.attachment?
+    #assert_equal true, feed.items.first.enclosure?
+  #end
 
 end

--- a/test/test_attachments_live.rb
+++ b/test/test_attachments_live.rb
@@ -8,15 +8,15 @@ require 'helper'
 
 class TestAttachmentsLive < MiniTest::Test
 
-  #def test_atom_enclose
-    #feed = fetch_and_parse_feed( 'http://www.lse.ac.uk/assets/richmedia/webFeeds/publicLecturesAndEvents_AtomAllMediaTypesLatest100.xml' )
+  def test_atom_enclose
+    feed = fetch_and_parse_feed( 'http://www.lse.ac.uk/assets/richmedia/webFeeds/publicLecturesAndEvents_AtomAllMediaTypesLatest100.xml' )
 
-    #assert_equal 'audio/mpeg', feed.items.first.attachment.type
-    #assert_equal 'audio/mpeg', feed.items.first.enclosure.type
+    assert_equal 'audio/mpeg', feed.items.first.attachment.type
+    assert_equal 'audio/mpeg', feed.items.first.enclosure.type
 
-    #assert_equal true, feed.items.first.attachment?
-    #assert_equal true, feed.items.first.enclosure?
-  #end
+    assert_equal true, feed.items.first.attachment?
+    assert_equal true, feed.items.first.enclosure?
+  end
 
   def test_atom_media
     feed = fetch_and_parse_feed( 'http://www.youtube.com/feeds/videos.xml?channel_id=UCZUT79WUUpZlZ-XMF7l4CFg' )
@@ -48,14 +48,14 @@ class TestAttachmentsLive < MiniTest::Test
     assert feed.items.first.attachments.first.description
   end
 
-  #def test_rss_enclosure
-    #feed = fetch_and_parse_feed( 'http://www.radiofreesatan.com/category/featured/feed/' )
+  def test_rss_enclosure
+    feed = fetch_and_parse_feed( 'http://www.radiofreesatan.com/category/featured/feed/' )
 
-    #assert_equal 'audio/mpeg', feed.items.first.attachment.type
-    #assert_equal 'audio/mpeg', feed.items.first.enclosure.type
+    assert_equal 'audio/mpeg', feed.items.first.attachment.type
+    assert_equal 'audio/mpeg', feed.items.first.enclosure.type
 
-    #assert_equal true, feed.items.first.attachment?
-    #assert_equal true, feed.items.first.enclosure?
-  #end
+    assert_equal true, feed.items.first.attachment?
+    assert_equal true, feed.items.first.enclosure?
+  end
 
 end


### PR DESCRIPTION
This is an unfinished proposal. Missing testcases, awaiting discussion/approval.

As mentioned in https://github.com/feedparser/feedparser/issues/4, feedparser is currently ignoring the yahoo media: items, which are relevant since Youtube is using them to transport meta information. See https://github.com/pipes-digital/pipes/issues/64 for an example use case.

Sadly you were correct in your last comment back then: The issue is that the RSS module is not transporting the namespace elements, at least as far as I could see.

Now, this code does three things:

 1. It extends the attachment object for the elements youtube uses
 1. It adds Oga as dependency, which I'd propose as an easier to install alternative to nokogiri. 
 1. It then uses Oga to parse the raw XML to set the additional attachment fields.


Note that I did not see a straightforward way how to use the community field and subfields, and the thumbnail has additional information like height and width that should be preserved (in a hash? an object?).

What do you think, should we go forward with that? I did test only the ATOM codepath so far (because of Youtube being ATOM) and it worked fine.