### PR TITLE
Fix: media element w/o duration would overwrite enclosure's length

### DIFF
--- a/feedparser/lib/feedparser/builder/rss.rb
+++ b/feedparser/lib/feedparser/builder/rss.rb
@@ -240,7 +240,9 @@ class RssFeedBuilder
       contentElement = xml_item.at_xpath('media:content') || xml_item.at_xpath('media:group/media:content')
       if contentElement
         feed_item.attachments.first.url = contentElement.get('url')
-        feed_item.attachments.first.length = contentElement.get('duration')
+        # The media:content element sometimes have no duration set, but enclosures do and would be
+        # parsed first. We need to avoid overwriting a set length with nil
+        feed_item.attachments.first.length = contentElement.get('duration') if contentElement.get('duration')
       end
 
       thumbnailElement = xml_item.at_xpath('media:thumbnail') || xml_item.at_xpath('media:content/media:thumbnail') || xml_item.at_xpath('media:group/media:thumbnail')


### PR DESCRIPTION
I stumbled over a podcast feed that had both an enclosure and a media:content element, but the media element had no duration set. Feedparser would end up with an attachment that had a size element set to nil. That's problematic, especially since ruby's rss lib will not create the enclosure element without a length element (it is required by spec).